### PR TITLE
Prepare 3.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [v3.0.0](https://github.com/nextcloud/stylelint-config/tree/v3.0.0) (2024-04-15)
+[Full Changelog](https://github.com/nextcloud/stylelint-config/compare/v2.4.0...v3.0.0)
+
+### Breaking changes :boom:
+stylelint was updated to version 16.0 which drops all stylistic changes.
+The means stylelint only will check for code quality but not for stylistic rules.
+So it is now recommended to instead use `prettier` with `@nextcloud/prettier-config` for stylistic rules.
+See also [Nextcloud prettier setup](https://github.com/nextcloud-libraries/nextcloud-prettier-config/blob/main/README.md#setup).
+
+### Changed
+* Updated stylelint and require stylelint version 16.2.0 or later.
+
 ## [v2.4.0](https://github.com/nextcloud/stylelint-config/tree/v2.4.0) (2024-01-23)
 
 [Full Changelog](https://github.com/nextcloud/stylelint-config/compare/v2.3.1...v2.4.0)

--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@ module.exports = {
 	ignoreFiles: ['**/*.js', '**/*.ts', '**/*.svg'],
 	rules: {
 		'selector-type-no-unknown': null,
-		'number-leading-zero': null,
 		'rule-empty-line-before': [
 			'always',
 			{
@@ -21,7 +20,6 @@ module.exports = {
 		],
 		'comment-empty-line-before': null,
 		'selector-type-case': null,
-		'selector-list-comma-newline-after': null,
 		'no-descending-specificity': null,
 		'selector-pseudo-class-no-unknown': [
 			true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@nextcloud/stylelint-config",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/stylelint-config",
-      "version": "2.4.0",
+      "version": "3.0.0",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
-        "stylelint": "^16.2.0",
+        "stylelint": "^16.3.1",
         "stylelint-config-recommended-scss": "^14.0.0",
         "stylelint-config-recommended-vue": "^1.5.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/stylelint-config",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "description": "Stylelint shared config for nextcloud vue.js apps",
   "main": "index.js",
   "repository": {
@@ -13,7 +13,7 @@
     "stylelint-config-recommended-vue": "^1.5.0"
   },
   "devDependencies": {
-    "stylelint": "^16.2.0",
+    "stylelint": "^16.3.1",
     "stylelint-config-recommended-scss": "^14.0.0",
     "stylelint-config-recommended-vue": "^1.5.0"
   },


### PR DESCRIPTION
## [v3.0.0](https://github.com/nextcloud/stylelint-config/tree/v3.0.0) (2024-04-15)
[Full Changelog](https://github.com/nextcloud/stylelint-config/compare/v2.4.0...v3.0.0)

### Breaking changes :boom:
stylelint was updated to version 16.0 which drops all stylistic changes.
The means stylelint only will check for code quality but not for stylistic rules.
So it is now recommended to instead use `prettier` with `@nextcloud/prettier-config` for stylistic rules.
See also [Nextcloud prettier setup](https://github.com/nextcloud-libraries/nextcloud-prettier-config/blob/main/README.md#setup).

### Changed
* Updated stylelint and require stylelint version 16.2.0 or later.