### PR TITLE
fix: Remove stylistic rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,10 @@ module.exports = {
 	],
 	ignoreFiles: ['**/*.js', '**/*.ts', '**/*.svg'],
 	rules: {
+		// Stylistic rules conflicting with prettier
+		'scss/operator-no-newline-after': null,
+		'scss/operator-no-newline-before': null,
+
 		'selector-type-no-unknown': null,
 		'rule-empty-line-before': [
 			'always',


### PR DESCRIPTION
With stylelint 16 stylistic rules were dropped and we recommended using prettier. But we include the scss plugin which still has stylelistic rules that conflict. So also disable those rules.