### PR TITLE
chore: Prepare 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v3.0.1](https://github.com/nextcloud/stylelint-config/tree/v3.0.1) (2024-05-07)
+
+### Fixed
+
+* fix: Remove stylistic rules also for scss
+
 ## [v3.0.0](https://github.com/nextcloud/stylelint-config/tree/v3.0.0) (2024-04-15)
 [Full Changelog](https://github.com/nextcloud/stylelint-config/compare/v2.4.0...v3.0.0)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/stylelint-config",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/stylelint-config",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
         "stylelint": "^16.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/stylelint-config",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Stylelint shared config for nextcloud vue.js apps",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
## [v3.0.1](https://github.com/nextcloud/stylelint-config/tree/v3.0.1) (2024-05-07)

### Fixed

* fix: Remove stylistic rules also for scss