### PR TITLE
fix(use-logical): ignore properties with `/-(top|bottom)-/`

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,6 +59,9 @@ module.exports = {
 					// Position properties with directional suffixes
 					/-top$/,
 					/-bottom$/,
+					// also for e.g. border-bottom-color
+					/-top-/,
+					/-bottom-/,
 					// Size properties
 					'width',
 					'max-width',


### PR DESCRIPTION
I missed this change added in `nextcloud-vue`, but not here.