### PR TITLE
chore(release): v3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 -->
 # Changelog
 
+## [v3.1.0](https://github.com/nextcloud/stylelint-config/tree/v3.1.0) (2025-05-22)
+
+### Added
+* Add `csstools/use-logical` to warn about LTR-RTL properties [\#121](https://github.com/nextcloud-libraries/stylelint-config/pull/121) ([ShGKme](https://github.com/ShGKme))
+
+### Changed
+* Updated stylelint and require stylelint version 16.13.2 or later
+* Add SPDX header [\#109](https://github.com/nextcloud-libraries/stylelint-config/pull/109) ([AndyScherzinger](https://github.com/AndyScherzinger))
+
 ## [v3.0.1](https://github.com/nextcloud/stylelint-config/tree/v3.0.1) (2024-05-07)
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/stylelint-config",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/stylelint-config",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "stylelint-use-logical": "^2.1.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/stylelint-config",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Stylelint shared config for nextcloud vue.js apps",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
## [v3.1.0](https://github.com/nextcloud/stylelint-config/tree/v3.1.0) (2025-05-22)

### Added
* Add `csstools/use-logical` to warn about LTR-RTL properties [\#121](https://github.com/nextcloud-libraries/stylelint-config/pull/121) ([ShGKme](https://github.com/ShGKme))

### Changed
* Updated stylelint and require stylelint version 16.13.2 or later
* Add SPDX header [\#109](https://github.com/nextcloud-libraries/stylelint-config/pull/109) ([AndyScherzinger](https://github.com/AndyScherzinger))