### PR TITLE
feat!: bring back stylistic rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 -->
 # Changelog
 
+## [v4.0.0](https://github.com/nextcloud/stylelint-config/tree/v4.0.0) (unreleased)
+
+### Breaking changes :boom:
+This configuration again contains stylistic rules.
+Due to no consensus on the prettier usage and the large user base of the configuration,
+the stylistic rules are again part of this configuration.
+
+If you are using prettier, you can try to extend from `@nextcloud/prettier-config/config.js` instead.
+
 ## [v3.1.0](https://github.com/nextcloud/stylelint-config/tree/v3.1.0) (2025-05-22)
 
 ### Added

--- a/config-stylistic.js
+++ b/config-stylistic.js
@@ -1,0 +1,16 @@
+/*!
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/** @type {import('stylelint').Config} */
+module.exports = {
+	plugins: ['@stylistic/stylelint-plugin'],
+	extends: ['@stylistic/stylelint-config'],
+	rules: {
+		// overrides to comply with config v3
+		'@stylistic/indentation': 'tab',
+		'@stylistic/string-quotes': 'single',
+		'@stylistic/selector-list-comma-newline-after': 'always-multi-line',
+	}
+}

--- a/config.js
+++ b/config.js
@@ -1,0 +1,82 @@
+/*!
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/** @type {import('stylelint').Config} */
+module.exports = {
+	extends: [
+		'stylelint-config-recommended-scss',
+		'stylelint-config-recommended-vue/scss',
+	],
+	plugins: ['stylelint-use-logical'],
+	rules: {
+		'selector-type-no-unknown': null,
+		'rule-empty-line-before': [
+			'always',
+			{
+				ignore: ['after-comment', 'inside-block'],
+			},
+		],
+		'declaration-empty-line-before': [
+			'never',
+			{
+				ignore: ['after-declaration'],
+			},
+		],
+		'comment-empty-line-before': null,
+		'selector-type-case': null,
+		'no-descending-specificity': null,
+		'selector-pseudo-class-no-unknown': [
+			true,
+			{
+				// vue deep pseudo-class
+				ignorePseudoClasses: ['deep'],
+			},
+		],
+		'selector-pseudo-element-no-unknown': [
+			true,
+			{
+				// Vue deep pseudo-element
+				ignorePseudoElements: ['deep'],
+			},
+		],
+
+		// Logical properties
+		'csstools/use-logical': [
+			'always',
+			{
+				// TODO: make it an error in the next major or large release
+				severity: 'warning',
+				// Only lint LTR-RTL properties for now
+				except: [
+					// Position properties
+					'top',
+					'bottom',
+					// Position properties with directional suffixes
+					/-top$/,
+					/-bottom$/,
+					// also for e.g. border-bottom-color
+					/-top-/,
+					/-bottom-/,
+					// Size properties
+					'width',
+					'max-width',
+					'min-width',
+					'height',
+					'max-height',
+					'min-height',
+				],
+			},
+		],
+	},
+	overrides: [
+		{
+			files: ['*.scss', '**/*.scss'],
+			rules: {
+				'at-rule-no-unknown': null,
+				'scss/at-rule-no-unknown': true,
+			},
+		},
+	],
+}

--- a/index.js
+++ b/index.js
@@ -1,85 +1,13 @@
-/**
+/*!
  * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
+/** @type {import('stylelint').Config} */
 module.exports = {
 	extends: [
-		'stylelint-config-recommended-scss',
-		'stylelint-config-recommended-vue/scss'
+		'./config.js',
+		'./config-stylistic.js',
 	],
 	ignoreFiles: ['**/*.js', '**/*.ts', '**/*.svg'],
-	plugins: ['stylelint-use-logical'],
-	rules: {
-		// Stylistic rules conflicting with prettier
-		'scss/operator-no-newline-after': null,
-		'scss/operator-no-newline-before': null,
-
-		'selector-type-no-unknown': null,
-		'rule-empty-line-before': [
-			'always',
-			{
-				ignore: ['after-comment', 'inside-block'],
-			},
-		],
-		'declaration-empty-line-before': [
-			'never',
-			{
-				ignore: ['after-declaration'],
-			},
-		],
-		'comment-empty-line-before': null,
-		'selector-type-case': null,
-		'no-descending-specificity': null,
-		'selector-pseudo-class-no-unknown': [
-			true,
-			{
-				// vue deep pseudo-class
-				ignorePseudoClasses: ['deep'],
-			},
-		],
-		'selector-pseudo-element-no-unknown': [
-			true,
-			{
-				// Vue deep pseudo-element
-				ignorePseudoElements: ['deep'],
-			},
-		],
-
-		// Logical properties
-		'csstools/use-logical': [
-			'always',
-			{
-				// TODO: make it an error in the next major or large release
-				severity: 'warning',
-				// Only lint LTR-RTL properties for now
-				except: [
-					// Position properties
-					'top',
-					'bottom',
-					// Position properties with directional suffixes
-					/-top$/,
-					/-bottom$/,
-					// also for e.g. border-bottom-color
-					/-top-/,
-					/-bottom-/,
-					// Size properties
-					'width',
-					'max-width',
-					'min-width',
-					'height',
-					'max-height',
-					'min-height',
-				],
-			},
-		],
-	},
-	overrides: [
-		{
-			files: ['*.scss', '**/*.scss'],
-			rules: {
-				'at-rule-no-unknown': null,
-				'scss/at-rule-no-unknown': true,
-			},
-		},
-	],
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,29 +1,33 @@
 {
   "name": "@nextcloud/stylelint-config",
-  "version": "3.1.0",
+  "version": "4.0.0-alpha",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/stylelint-config",
-      "version": "3.1.0",
+      "version": "4.0.0-alpha",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "stylelint-use-logical": "^2.1.2"
       },
       "devDependencies": {
-        "stylelint": "^16.13.2",
+        "@stylistic/stylelint-config": "^2.0.0",
+        "@stylistic/stylelint-plugin": "^3.1.2",
+        "stylelint": "^16.20.0",
         "stylelint-config-recommended-scss": "^15.0.1",
-        "stylelint-config-recommended-vue": "^1.5.0"
+        "stylelint-config-recommended-vue": "^1.6.0"
       },
       "engines": {
         "node": "^20.0.0",
         "npm": "^10.0.0"
       },
       "peerDependencies": {
-        "stylelint": "^16.13.2",
+        "@stylistic/stylelint-config": "^2.0.0",
+        "@stylistic/stylelint-plugin": "^3.1.2",
+        "stylelint": "^16.20.0",
         "stylelint-config-recommended-scss": "^15.0.1",
-        "stylelint-config-recommended-vue": "^1.5.0"
+        "stylelint-config-recommended-vue": "^1.6.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -171,6 +175,83 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@stylistic/stylelint-config": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/stylelint-config/-/stylelint-config-2.0.0.tgz",
+      "integrity": "sha512-8J4YAxggy2Nzkb8KJIOLbtMXTPZ5gpKVmyhiiuKEUgCl9XFND5lM0e/ZZBMGEYZ68h5qcsS/jgg1wh235erRAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@stylistic/stylelint-plugin": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.12 || >=20.9"
+      },
+      "peerDependencies": {
+        "stylelint": "^16.8.0"
+      }
+    },
+    "node_modules/@stylistic/stylelint-plugin": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@stylistic/stylelint-plugin/-/stylelint-plugin-3.1.2.tgz",
+      "integrity": "sha512-tylFJGMQo62alGazK74MNxFjMagYOHmBZiePZFOJK2n13JZta0uVkB3Bh5qodUmOLtRH+uxH297EibK14UKm8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.1",
+        "@csstools/css-tokenizer": "^3.0.1",
+        "@csstools/media-query-list-parser": "^3.0.1",
+        "is-plain-object": "^5.0.0",
+        "postcss-selector-parser": "^6.1.2",
+        "postcss-value-parser": "^4.2.0",
+        "style-search": "^0.1.0",
+        "stylelint": "^16.8.2"
+      },
+      "engines": {
+        "node": "^18.12 || >=20.9"
+      },
+      "peerDependencies": {
+        "stylelint": "^16.8.0"
+      }
+    },
+    "node_modules/@stylistic/stylelint-plugin/node_modules/@csstools/media-query-list-parser": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-3.0.1.tgz",
+      "integrity": "sha512-HNo8gGD02kHmcbX6PvCoUuOQvn4szyB9ca63vZHKX5A81QytgDG4oxG4IaEfHTlEZSZ6MjPEMWIVU+zF2PZcgw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.1",
+        "@csstools/css-tokenizer": "^3.0.1"
+      }
+    },
+    "node_modules/@stylistic/stylelint-plugin/node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ajv": {
@@ -1325,6 +1406,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/style-search": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
+      "integrity": "sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/stylelint": {
       "version": "16.20.0",

--- a/package.json
+++ b/package.json
@@ -1,38 +1,42 @@
 {
   "name": "@nextcloud/stylelint-config",
-  "version": "3.1.0",
+  "version": "4.0.0-alpha",
   "description": "Stylelint shared config for nextcloud vue.js apps",
-  "main": "index.js",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/nextcloud-libraries/stylelint-config.git"
-  },
-  "peerDependencies": {
-    "stylelint": "^16.13.2",
-    "stylelint-config-recommended-scss": "^15.0.1",
-    "stylelint-config-recommended-vue": "^1.5.0"
-  },
-  "devDependencies": {
-    "stylelint": "^16.13.2",
-    "stylelint-config-recommended-scss": "^15.0.1",
-    "stylelint-config-recommended-vue": "^1.5.0"
-  },
   "keywords": [
     "stylelint",
     "config",
     "nextcloud"
   ],
-  "author": "John Molakvoæ <skjnldsv@protonmail.com>",
-  "license": "AGPL-3.0-or-later",
+  "homepage": "https://github.com/nextcloud-libraries/stylelint-config#readme",
   "bugs": {
     "url": "https://github.com/nextcloud-libraries/stylelint-config/issues"
   },
-  "homepage": "https://github.com/nextcloud-libraries/stylelint-config#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nextcloud-libraries/stylelint-config.git"
+  },
+  "license": "AGPL-3.0-or-later",
+  "author": "John Molakvoæ <skjnldsv@protonmail.com>",
+  "main": "index.js",
+  "dependencies": {
+    "stylelint-use-logical": "^2.1.2"
+  },
+  "devDependencies": {
+    "@stylistic/stylelint-config": "^2.0.0",
+    "@stylistic/stylelint-plugin": "^3.1.2",
+    "stylelint": "^16.20.0",
+    "stylelint-config-recommended-scss": "^15.0.1",
+    "stylelint-config-recommended-vue": "^1.6.0"
+  },
+  "peerDependencies": {
+    "@stylistic/stylelint-config": "^2.0.0",
+    "@stylistic/stylelint-plugin": "^3.1.2",
+    "stylelint": "^16.20.0",
+    "stylelint-config-recommended-scss": "^15.0.1",
+    "stylelint-config-recommended-vue": "^1.6.0"
+  },
   "engines": {
     "node": "^20.0.0",
     "npm": "^10.0.0"
-  },
-  "dependencies": {
-    "stylelint-use-logical": "^2.1.2"
   }
 }


### PR DESCRIPTION
For ESLint we are doing the same due to missing consensus on moving to prettier and the already large user base of `@nextcloud/eslint-config` and `@nextcloud/stylelint-config`.