### PR TITLE
fix: temporarily disable scss/load-partial-extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,6 +45,9 @@ module.exports = {
 			},
 		],
 
+		// Disable until we decide if we want "always" or "never"
+		'scss/load-partial-extension': null,
+
 		// Logical properties
 		'csstools/use-logical': [
 			'always',


### PR DESCRIPTION
- `scss/load-partial-extension` was added in stylelint-scss v6.4.0 as a replacement for `at-import-partial-extension`
- It works differently and causes errors on the code that previously pass linting
- Temporarily disable the rule to avoid errors
- Enable with https://github.com/nextcloud-libraries/stylelint-config/issues/134