### PR TITLE
chore: prepare v3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 -->
 # Changelog
 
+## [v3.1.1](https://github.com/nextcloud/stylelint-config/tree/v3.1.1) (2025-10-06)
+
+### Fixed
+* fix: allow all <style scoped> and CSS Modules pseudo selectors [\#140](https://github.com/nextcloud-libraries/stylelint-config/pull/140) ([ShGKme](https://github.com/ShGKme))
+* fix: temporarily disable scss/load-partial-extension [\#141](https://github.com/nextcloud-libraries/stylelint-config/pull/141) ([ShGKme](https://github.com/ShGKme))
+
+### Changed
+* ci: update npm-publish.yml workflow from template [\#139](https://github.com/nextcloud-libraries/stylelint-config/pull/139) ([susnux](https://github.com/susnux))
+* ci: update reuse.yml workflow from template [\#138](https://github.com/nextcloud-libraries/stylelint-config/pull/138) ([susnux](https://github.com/susnux))
+* chore: update node version requirement [\#143](https://github.com/nextcloud-libraries/stylelint-config/pull/143) ([susnux](https://github.com/susnux))
+
 ## [v3.1.0](https://github.com/nextcloud/stylelint-config/tree/v3.1.0) (2025-05-22)
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/stylelint-config",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/stylelint-config",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "stylelint-use-logical": "^2.1.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/stylelint-config",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Stylelint shared config for nextcloud vue.js apps",
   "keywords": [
     "stylelint",


### PR DESCRIPTION
## [v3.1.1](https://github.com/nextcloud/stylelint-config/tree/v3.1.1) (2025-10-02)

### Fixed
* fix: allow all <style scoped> and CSS Modules pseudo selectors [\#140](https://github.com/nextcloud-libraries/stylelint-config/pull/140) ([ShGKme](https://github.com/ShGKme))
* fix: temporarily disable scss/load-partial-extension [\#141](https://github.com/nextcloud-libraries/stylelint-config/pull/141) ([ShGKme](https://github.com/ShGKme))

### Changed
* ci: update npm-publish.yml workflow from template [\#139](https://github.com/nextcloud-libraries/stylelint-config/pull/139) ([susnux](https://github.com/susnux))
* ci: update reuse.yml workflow from template [\#138](https://github.com/nextcloud-libraries/stylelint-config/pull/138) ([susnux](https://github.com/susnux))