### PR TITLE
fix: temporarily disable `no-invalid-position-declaration`

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,6 +56,13 @@ module.exports = {
 			},
 		],
 
+		// Added in 16.23.0 to prevent CSS variables declaration outside rules
+		// The rule often results in false positives on update due to multiple csstools packages, requiring "npm dedupe"
+		// See: https://github.com/stylelint/stylelint/issues/9252
+		// The rule doesn't seem to be very useful
+		// Disabling to avoid false positives on updates until the upstream issue is resolved
+		'no-invalid-position-declaration': null,
+
 		// Consistent with ES imports
 		'scss/load-partial-extension': 'always',
 


### PR DESCRIPTION
- Rule description: https://stylelint.io/user-guide/rules/no-invalid-position-declaration/
- It often results in false positives on update due to multiple csstools packages requiring `npm dedupe`
  - Ref: https://github.com/stylelint/stylelint/issues/9252
  - Examples:
    - https://github.com/nextcloud-libraries/nextcloud-vue/pull/8502
    - https://github.com/nextcloud-libraries/nextcloud-vue/pull/8431
- The rule doesn't seem very important for me, I'd propose disabling it until the issue is resolved