### PR TITLE
chore(release): v3.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 -->
 # Changelog
 
+## [v3.2.2](https://github.com/nextcloud-libraries/stylelint-config/compare/v3.2.1...v3.2.2) (2026-05-07)
+### Fixed
+* fix: temporarily disable `no-invalid-position-declaration` [\#171](https://github.com/nextcloud-libraries/stylelint-config/pull/171) ([ShGKme](https://github.com/ShGKme))
+
+### Changed
+* Updated dependencies:
+  * Bump `stylelint` to 17.9.1
+  * Bump `stylelint-config-recommended-scss` to 17.0.1
+
 ## [v3.2.1](https://github.com/nextcloud/stylelint-config/tree/v3.2.1) (2026-02-05)
 ### Changed
 * chore(deps): pin stylelint and stylelint-use-logical to remove overrides [\#154](https://github.com/nextcloud-libraries/stylelint-config/pull/154)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/stylelint-config",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/stylelint-config",
-      "version": "3.2.1",
+      "version": "3.2.2",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "stylelint-use-logical": "^2.1.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/stylelint-config",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Stylelint shared config for nextcloud vue.js apps",
   "keywords": [
     "stylelint",


### PR DESCRIPTION
## [v3.2.2](https://github.com/nextcloud-libraries/stylelint-config/compare/v3.2.1...v3.2.2) (2026-05-07)
### Fixed
* fix: temporarily disable `no-invalid-position-declaration` [\#171](https://github.com/nextcloud-libraries/stylelint-config/pull/171) ([ShGKme](https://github.com/ShGKme))

### Changed
* Updated dependencies:
  * Bump `stylelint` to 17.9.1
  * Bump `stylelint-config-recommended-scss` to 17.0.1

### What's Changed

<details>

* chore(deps-dev): Bump stylelint from 17.1.1 to 17.3.0 by @dependabot[bot] in https://github.com/nextcloud-libraries/stylelint-config/pull/157
* chore(deps): Bump flatted from 3.3.3 to 3.4.2 by @dependabot[bot] in https://github.com/nextcloud-libraries/stylelint-config/pull/162
* chore(deps-dev): Bump stylelint from 17.3.0 to 17.6.0 by @dependabot[bot] in https://github.com/nextcloud-libraries/stylelint-config/pull/164
* [main] ci: update all workflow templates from organization template repository by @nextcloud-command in https://github.com/nextcloud-libraries/stylelint-config/pull/165
* chore(deps-dev): Bump stylelint-config-recommended-scss from 17.0.0 to 17.0.1 by @dependabot[bot] in https://github.com/nextcloud-libraries/stylelint-config/pull/166
* chore(deps-dev): Bump stylelint from 17.6.0 to 17.9.1 by @dependabot[bot] in https://github.com/nextcloud-libraries/stylelint-config/pull/170
* ci: update npm-publish.yml workflow from template by @nextcloud-command in https://github.com/nextcloud-libraries/stylelint-config/pull/167
* fix: temporarily disable `no-invalid-position-declaration` by @ShGKme in https://github.com/nextcloud-libraries/stylelint-config/pull/171
* chore(deps): Bump ajv from 8.17.1 to 8.20.0 by @dependabot[bot] in https://github.com/nextcloud-libraries/stylelint-config/pull/158

</details>